### PR TITLE
UserExceptionWithContextInterface

### DIFF
--- a/src/ExceptionWithContextInterface.php
+++ b/src/ExceptionWithContextInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\CommonExceptions;
 
-interface UserExceptionWithContextInterface extends UserExceptionInterface
+use Throwable;
+
+interface ExceptionWithContextInterface extends Throwable
 {
     public function getContext(): array;
 }

--- a/src/UserExceptionWithContextInterface.php
+++ b/src/UserExceptionWithContextInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\CommonExceptions;
+
+interface UserExceptionWithContextInterface extends UserExceptionInterface
+{
+    public function getContext(): array;
+}


### PR DESCRIPTION
Bylo by fajn mět možnost v api-error-controll vracet nějaké kontextové info.

Teď vyhodím UserExceptionInterface a jediné co se može dostat do response je message a statusCode.
Když mám třeba form tak je dost na hovno hodit do message co všechno je špatně.
Přes UserExceptionWithContext, može api error control hodit do response field třeba `context` nebo `additionalInformation` nebo něco podobného a z aplikace jde obsah řídit přes `getContext` metodu.

Takže response by nebyla.
```
{
   "error":"Validation Exception.",
   "code":422,
   "exceptionId":"123",
   "status":"error"
}
```
ale
```
{
   "error":"Validation Exception.",
   "code":422,
   "exceptionId":"123",
   "status":"error",
   "context":{
      "validationErrors":[
         "name":         [
            "Should not be blank."
         ]
      ]
   }
}
```